### PR TITLE
Fix `The product that was requested doesn't exist.`

### DIFF
--- a/Model/Resolver/Product/DataProvider/ProductAttributeDataProvider.php
+++ b/Model/Resolver/Product/DataProvider/ProductAttributeDataProvider.php
@@ -38,7 +38,11 @@ class ProductAttributeDataProvider extends Template
     public function getAttributesBySku(string $sku): array
     {
         $storeId = $this->storeManager->getStore()->getId();
-        $product = $this->getProductBySku($sku, $storeId);
+        try{
+            $product = $this->getProductBySku($sku, $storeId);
+        }catch (\Throwable $e){
+            return [];
+        }
         $attributes = $product->getAttributes();
 
         $attributeData = [];


### PR DESCRIPTION
While retrieving `extra_attributes` I ran into the error `The product that was requested doesn't exist. Verify the product and try again.`. Not sure why this was happening as I would think all the products exist but here we are..

Adding a try/catch fixed the issue and just returns empty `extra_attributes` for that product.